### PR TITLE
Tighten up embed URL regexes a bit

### DIFF
--- a/client/lib/ui/Message.js
+++ b/client/lib/ui/Message.js
@@ -428,7 +428,7 @@ const Message = createReactClass({
       })
       return ''
     })
-    content = content.replace(/(?:https?:\/\/)?(imgs\.xkcd\.com\/comics\/.*\.(?:png|jpg)|i\.ytimg\.com\/.*\.jpg)/g, (match, imgUrl) => {
+    content = content.replace(/(?:https?:\/\/)?(imgs\.xkcd\.com\/comics\/\S*\.(?:png|jpg)|i\.ytimg\.com\/\S*\.jpg)/g, (match, imgUrl) => {
       embeds.push({
         link: '//' + imgUrl,
         props: {


### PR DESCRIPTION
Another very simple obvious fix from *moi*.

- - -

It's basically impossible to constrain xkcd comic URLs any further, as even e.g. https://imgs.xkcd.com/comics/(.png is an actual image.

I considered constraining the youtube thumbnails URLs to valid-looking ones, but it seemed like way too much effort for too little payoff, especially since the format has changed before & could change in the future, and we don't even support all the possible thumbnail domains.

- - -

Other things I considered was prepending a `\b` to the regexes but I realized even tho it would "fix" e.g. `bhttps://imgur.com/imGuR` being shown (maybe better to be more forgiving in such a case...?), it wouldn't fix e.g. `https://web.archive.org/web/2016/http://imgur.com/b7pOX75` from being mangled, which is seems worth fixing to me if possible. But to fix that would require parsing out hyperlinks before embeds, I think... which sounds difficult to refactor and is a completely different part of the code

- - - 

Dunno if you can tell from the branch name, but this took me 3 times to get this commit right...
The Github:tm: web editor really, *really*, ***realllly*** __SUCKS__ -- Plz merge out of pity for my suffering! ...Anyway

- - - 

Also, why are the embed URL regexes buried in lib/ui/Message.js when the embedder itself is in lib/embed.js?
I think maybe the embed URL extraction should be extracted into a separate own file/module that's maybe closer to embed.js? 
or at least named smth that makes finding it easier. ok, that's all (for now)