### PR TITLE
Avoid 'ugly' URLs by POSTing to RoomSwitcher form

### DIFF
--- a/client/lib/ui/RoomSwitcher.js
+++ b/client/lib/ui/RoomSwitcher.js
@@ -53,7 +53,7 @@ export default createReactClass({
     const url = this.state.valid ? '/room/' + this.state.text + '/' : '#'
     // Note that valid is a tri-state value, with null being neither valid nor invalid
     return (
-      <form className={classNames('room-switcher', this.state.expanded && 'expanded')} action={url} target="_blank" onSubmit={this.apply}>
+      <form className={classNames('room-switcher', this.state.expanded && 'expanded')} action={url} method="post" target="_blank" onSubmit={this.apply}>
         <FastButton fastTouch type="button" className={this.state.expanded ? 'room-switcher-cancel' : 'room-switcher-expand'} title="go to another room" onClick={this.toggle} />
         {this.state.expanded && <span className="room-switcher-prompt">go to</span>}
         {this.state.expanded && (


### PR DESCRIPTION
An empty query string (a lone question mark) at the end of a URL is, well, rather ugly in my opinion.
So this commit fixes that (ab)using HTTP POST.

This should work in any & every browser, so long as the heim server continues to ignore any data POST-ed to the /room/{room}/ endpoint.