### PR TITLE
Fix emoji zooms not eclipsing all other elements

### DIFF
--- a/client/lib/main.less
+++ b/client/lib/main.less
@@ -1452,15 +1452,19 @@ iframe.js {
       .emoji {
         height: 19px;
         width: 19px;
+        position: relative;
 
         transition: transform linear 0.1s,
                     background linear 0.1s,
-                    z-index linear 0.1s;
+                    z-index step-start 0.1s;
 
         &:hover {
           transform: scale(5);
           background-color: rgba(255, 255, 255, 0.25);
           z-index: 100;
+          transition: transform linear 0.1s,
+                      background linear 0.1s,
+                      z-index step-end 0.1s;
           transition-delay: 1s;
         }
       }

--- a/client/lib/main.less
+++ b/client/lib/main.less
@@ -1453,10 +1453,10 @@ iframe.js {
         height: 19px;
         width: 19px;
         position: relative;
-
+        z-index: 0;
         transition: transform linear 0.1s,
                     background linear 0.1s,
-                    z-index step-start 0.1s;
+                    z-index step-end 0.1s;
 
         &:hover {
           transform: scale(5);
@@ -1464,7 +1464,7 @@ iframe.js {
           z-index: 100;
           transition: transform linear 0.1s,
                       background linear 0.1s,
-                      z-index step-end 0.1s;
+                      z-index step-start 0.1s;
           transition-delay: 1s;
         }
       }


### PR DESCRIPTION
Based on this: <https://stackoverflow.com/a/19311234>

Except this does not entirely fix it, as can be seen most easily by hovering over the first of two emojis in a row; on zoom-in, the emoji eclipses all else, including its sibling; but on zoom-out, its sibling eclipses it. I hope to fix this, but for now, this will have to suffice

Also, yes, it could probably be DRY-er... if you want me to wring out the code til its bone dry just let me know