### PR TITLE
Align text of messages with their embeds on mobile

### DIFF
--- a/client/lib/style/main.less
+++ b/client/lib/style/main.less
@@ -2455,7 +2455,7 @@ iframe.js {
         display: inline;
       }
 
-      .content {
+      &:not(.has-embed) .content {
         position: relative;
         left: .5em;
 


### PR DESCRIPTION
Despite this commit itself having been authored in the web client,
I did actually locally test this change and it seems to work fine.
I mean, i don't know how it could possibly *break* anything, it's such a simple change...
but anyways.

I have also adjusted the relevant patch for Gold Mode and can send it over after this has been merged :3

(P.S. I maaaay have spent nearly an hour honing the exact phrasing of the commit message so that all the lines would line-up 🤪)

(P.P.S. i am most embarrassed that i did not notice the already extant `.has-embed` class earlier. derp! xP)