### PR TITLE
Fix typo and latent bug in about pages' navbar CSS

### DIFF
--- a/client/site/site.less
+++ b/client/site/site.less
@@ -177,7 +177,7 @@ body.page {
       z-index: 15;
       height: 100%;
 
-      :hover {
+      &:hover {
         background: white;
       }
     }


### PR DESCRIPTION
i discovered this on accident whilst [userstyling](https://gist.github.com/jeremyredhead/038a61ef5d117f0150b92d716c829f16); it's a dumb little change that's likely not needed, but it's technically an improvement, and it makes *my* life easier as a userstyle author and that's what matters at the end of the day right? :^)

also i wonder if i hit a new record for longest, most rediculous branch name... i may have overcompensated slightly for the tragic lack of funny branch name in my [previous PR](https://github.com/CylonicRaider/heim/pull/5)