### PR TITLE
Tab-completion improvements: Fix cursor position and don't trash undo history

### DIFF
--- a/client/lib/ui/ChatEntry.js
+++ b/client/lib/ui/ChatEntry.js
@@ -188,6 +188,9 @@ export default createReactClass({
     }
     const completed = (text[wordStart - 1] !== '@' ? '@' : '') + match
     input.value = input.value.substring(0, wordStart) + completed + input.value.substring(wordEnd)
+    const cursorPosition = wordStart + completed.length
+    input.selectionStart = cursorPosition
+    input.selectionEnd = cursorPosition
     this.saveEntryState()
   },
 

--- a/client/lib/ui/ChatEntry.js
+++ b/client/lib/ui/ChatEntry.js
@@ -186,13 +186,14 @@ export default createReactClass({
     if (!match) {
       return
     }
+
     const completed = (text[wordStart - 1] !== '@' ? '@' : '') + match
     const expectedValue = text.substring(0, wordStart) + completed + text.substring(wordEnd)
-    const cursorPosition = wordStart + completed.length
-    input.focus() // make sure we're really focused
     if (input.value === expectedValue) {
       return
     }
+
+    input.focus() // make sure we're really focused
     // commit a heresy and use execCommand to preserve undo history
     if (uidocument.queryCommandSupported('insertText')) {
       if (completed.startsWith(word)) {
@@ -208,11 +209,15 @@ export default createReactClass({
         uidocument.execCommand('insertText', false, completed)
       }
     }
+
     // bulwark against browser makers neutering execCommand
     if (input.value !== expectedValue) {
       input.value = expectedValue
     }
+
+    const cursorPosition = wordStart + completed.length
     input.setSelectionRange(cursorPosition, cursorPosition)
+
     this.saveEntryState()
   },
 

--- a/client/lib/ui/ChatEntry.js
+++ b/client/lib/ui/ChatEntry.js
@@ -187,8 +187,19 @@ export default createReactClass({
       return
     }
     const completed = (text[wordStart - 1] !== '@' ? '@' : '') + match
-    input.value = input.value.substring(0, wordStart) + completed + input.value.substring(wordEnd)
+    const expectedValue = text.substring(0, wordStart) + completed + text.substring(wordEnd)
     const cursorPosition = wordStart + completed.length
+    input.focus() // make sure we're really focused
+    const document = Heim.uidocument
+    // commit a heresy and use execCommand to preserve undo history
+    if (document.queryCommandSupported('insertText')) {
+      input.setSelectionRange(wordStart, wordEnd)
+      document.execCommand('insertText', false, completed)
+    }
+    // bulwark against browser makers neutering execCommand
+    if (input.value !== expectedValue) {
+      input.value = expectedValue
+    }
     input.setSelectionRange(cursorPosition, cursorPosition)
     this.saveEntryState()
   },

--- a/client/lib/ui/ChatEntry.js
+++ b/client/lib/ui/ChatEntry.js
@@ -193,8 +193,18 @@ export default createReactClass({
     const document = Heim.uidocument
     // commit a heresy and use execCommand to preserve undo history
     if (document.queryCommandSupported('insertText')) {
-      input.setSelectionRange(wordStart, wordEnd)
-      document.execCommand('insertText', false, completed)
+      if (completed.startsWith(word)) {
+        input.setSelectionRange(wordEnd, wordEnd)
+        const partial = completed.slice(word.length)
+        document.execCommand('insertText', false, partial)
+      } else if (completed.endsWith(word)) {
+        input.setSelectionRange(wordStart, wordStart)
+        const partial = completed.slice(0, -word.length)
+        document.execCommand('insertText', false, partial)
+      } else {
+        input.setSelectionRange(wordStart, wordEnd)
+        document.execCommand('insertText', false, completed)
+      }
     }
     // bulwark against browser makers neutering execCommand
     if (input.value !== expectedValue) {

--- a/client/lib/ui/ChatEntry.js
+++ b/client/lib/ui/ChatEntry.js
@@ -189,8 +189,7 @@ export default createReactClass({
     const completed = (text[wordStart - 1] !== '@' ? '@' : '') + match
     input.value = input.value.substring(0, wordStart) + completed + input.value.substring(wordEnd)
     const cursorPosition = wordStart + completed.length
-    input.selectionStart = cursorPosition
-    input.selectionEnd = cursorPosition
+    input.setSelectionRange(cursorPosition, cursorPosition)
     this.saveEntryState()
   },
 

--- a/client/lib/ui/ChatEntry.js
+++ b/client/lib/ui/ChatEntry.js
@@ -188,8 +188,8 @@ export default createReactClass({
     }
 
     const completed = (text[wordStart - 1] !== '@' ? '@' : '') + match
-    const expectedValue = text.substring(0, wordStart) + completed + text.substring(wordEnd)
-    if (input.value === expectedValue) {
+    const newValue = text.substring(0, wordStart) + completed + text.substring(wordEnd)
+    if (input.value === newValue) {
       return
     }
 
@@ -198,12 +198,10 @@ export default createReactClass({
     if (uidocument.queryCommandSupported('insertText')) {
       if (completed.startsWith(word)) {
         input.setSelectionRange(wordEnd, wordEnd)
-        const partial = completed.slice(word.length)
-        uidocument.execCommand('insertText', false, partial)
+        uidocument.execCommand('insertText', false, completed.slice(word.length))
       } else if (completed.endsWith(word)) {
         input.setSelectionRange(wordStart, wordStart)
-        const partial = completed.slice(0, -word.length)
-        uidocument.execCommand('insertText', false, partial)
+        uidocument.execCommand('insertText', false, completed.slice(0, -word.length))
       } else {
         input.setSelectionRange(wordStart, wordEnd)
         uidocument.execCommand('insertText', false, completed)
@@ -211,8 +209,8 @@ export default createReactClass({
     }
 
     // bulwark against browser makers neutering execCommand
-    if (input.value !== expectedValue) {
-      input.value = expectedValue
+    if (input.value !== newValue) {
+      input.value = newValue
     }
 
     const cursorPosition = wordStart + completed.length

--- a/client/lib/ui/ChatEntry.js
+++ b/client/lib/ui/ChatEntry.js
@@ -183,7 +183,7 @@ export default createReactClass({
       .map((user) => user.get('name', ''))
     const match = mention.rankCompletions(nameSeq, word).first()
 
-    if (!match) {
+    if (!match || match === word) {
       return
     }
     const completed = (text[wordStart - 1] !== '@' ? '@' : '') + match

--- a/client/lib/ui/ChatEntry.js
+++ b/client/lib/ui/ChatEntry.js
@@ -183,27 +183,29 @@ export default createReactClass({
       .map((user) => user.get('name', ''))
     const match = mention.rankCompletions(nameSeq, word).first()
 
-    if (!match || match === word) {
+    if (!match) {
       return
     }
     const completed = (text[wordStart - 1] !== '@' ? '@' : '') + match
     const expectedValue = text.substring(0, wordStart) + completed + text.substring(wordEnd)
     const cursorPosition = wordStart + completed.length
     input.focus() // make sure we're really focused
-    const document = Heim.uidocument
+    if (input.value === expectedValue) {
+      return
+    }
     // commit a heresy and use execCommand to preserve undo history
-    if (document.queryCommandSupported('insertText')) {
+    if (uidocument.queryCommandSupported('insertText')) {
       if (completed.startsWith(word)) {
         input.setSelectionRange(wordEnd, wordEnd)
         const partial = completed.slice(word.length)
-        document.execCommand('insertText', false, partial)
+        uidocument.execCommand('insertText', false, partial)
       } else if (completed.endsWith(word)) {
         input.setSelectionRange(wordStart, wordStart)
         const partial = completed.slice(0, -word.length)
-        document.execCommand('insertText', false, partial)
+        uidocument.execCommand('insertText', false, partial)
       } else {
         input.setSelectionRange(wordStart, wordEnd)
-        document.execCommand('insertText', false, completed)
+        uidocument.execCommand('insertText', false, completed)
       }
     }
     // bulwark against browser makers neutering execCommand


### PR DESCRIPTION
Place the text cursor at the end of the Tab-completed nickname, instead of the very end of the input message box.

I didn't technically test *this* patch against *this* parent commit, but I tested `input.selectionStart = wordStart + completed.length; input.selectionEnd = input.selectionStart` against 1ada4a34141758783b6b08a8ec9b2ddd30193b72 in my local and it seemed to do the trick so i think that's close enough. but ofc lemme know if i should test it proper and/or improve commit message etc